### PR TITLE
update contracts & subraph deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oracle-watcher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oracle-watcher",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@apollo/client": "^3.6.9",
         "@primer/octicons-react": "^17.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oracle-watcher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/src/getter.js
+++ b/src/getter.js
@@ -20,7 +20,7 @@ export const getDeals = gql`
       orderBy: timestamp
       orderDirection: desc
       where: {
-        app: "0x05a2915f4c5a87fd3084c59e1a379449a54985f5"
+        app: "0xe720999114874c2d8972da893e96909f3a578abb"
         timestamp_lt: $timestamp
       }
     ) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,23 +10,8 @@ export const SUBGRAPH_CLIENTS = {
     uri: 'https://thegraph.bellecour.iex.ec/subgraphs/name/bellecour/poco-v5',
     cache: new InMemoryCache(),
   }),
-  // oracle: new ApolloClient({
-  //   uri: 'http://192.168.1.87:8000/subgraphs/name/bellecour/oracle-watcher',
-  //   cache: new InMemoryCache(),
-  // }),
   oracle: new ApolloClient({
-    uri: 'https://graphnodeirx5kk8z-graphnoe.functions.fnc.fr-par.scw.cloud/subgraphs/name/bellecour/oracle-watcher',
+    uri: 'https://thegraph.bellecour.iex.ec/subgraphs/name/bellecour/of-oracle-watcher',
     cache: new InMemoryCache(),
   }),
-};
-
-export const confMap = {
-  viviani: {
-    ORACLE_APP_ADDRESS: '0xe7da3c01bbc71dacb05c30b7832214d82a045e70',
-    ORACLE_CONTRACT_ADDRESS: '0x8eceddd1377e52d23a46e2bd3df0afe35b526d5f',
-  },
-  bellecour: {
-    ORACLE_APP_ADDRESS: '0x05a2915f4c5a87fd3084c59e1a379449a54985f5',
-    ORACLE_CONTRACT_ADDRESS: '0x456891c78077d31f70ca027a46d68f84a2b814d4',
-  },
 };

--- a/subgraph/oracle-watcher/subgraph.yaml
+++ b/subgraph/oracle-watcher/subgraph.yaml
@@ -5,12 +5,12 @@ schema:
   file: ./schema.graphql
 dataSources:
   - kind: ethereum/contract
-    name: GenericOracle
+    name: VerifiedResultOracle
     network: bellecour
     source:
-      address: '0x456891C78077d31F70Ca027a46D68F84a2b814D4'
+      address: "0x36da71ccad7a67053f0a4d9d5f55b725c9a25a3e"
       abi: GenericOracle
-      startBlock: 16774861
+      startBlock: 19365010
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6

--- a/subgraph/oracle-watcher/subgraph.yaml
+++ b/subgraph/oracle-watcher/subgraph.yaml
@@ -1,6 +1,6 @@
 specVersion: 0.0.4
 description: iExecOracles
-repository: https://github.com/graphprotocol/example-subgraphs
+repository: https://github.com/iExecBlockchainComputing/bounty-iexec-oracle-watcher
 schema:
   file: ./schema.graphql
 dataSources:


### PR DESCRIPTION
Hi @0xDaVinciCode 
Thank you for your great work, we really appreciated the way your Oracle Watcher enhances iExec Oracle Factory.
To make it available for everyone, we decided to deploy your subgraph on iExec's graphnodes.
You can now use our subgraph deployment https://thegraph.bellecour.iex.ec/subgraphs/name/bellecour/of-oracle-watcher in your application front-end.
As you may also know, a new version of Oracle Factory with updated smart contracts has been released (https://github.com/iExecBlockchainComputing/generic-oracle-contracts/tree/v2.2.0). The address updates reflect the latest deployment.
Feel free to reintegrate these changes to your app.